### PR TITLE
Replace badges with new url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/emmanuelroussel/stockpile-app.svg?branch=master)](https://travis-ci.org/emmanuelroussel/stockpile-app)
-[![Coverage Status](https://coveralls.io/repos/github/emmanuelroussel/stockpile-app/badge.svg)](https://coveralls.io/github/emmanuelroussel/stockpile-app)
+[![Build Status](https://travis-ci.org/emroussel/stockpile-app.svg?branch=master)](https://travis-ci.org/emroussel/stockpile-app)
+[![Coverage Status](https://coveralls.io/repos/github/emroussel/stockpile-app/badge.svg?branch=master)](https://coveralls.io/github/emroussel/stockpile-app?branch=master)
 [![codebeat badge](https://codebeat.co/badges/d0387971-f205-4146-8946-b8a8a8d1d2e2)](https://codebeat.co/projects/github-com-emmanuelroussel-stockpile-app)
 
 # Stockpile App


### PR DESCRIPTION
Closes #223 

I wasn't able to rename the repo on Codebeat, so it will keep the old name. It seems to still function properly and creating a new project would remove all of the history.