### PR TITLE
Add ability to manage kits

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { StatusBar } from '@ionic-native/status-bar';
 import { LoginPage } from '../pages/login/login';
 import { TabsPage } from '../pages/tabs/tabs';
 import { ViewAccountPage } from '../pages/view-account/view-account';
+import { KitsPage } from '../pages/kits/kits';
 import { UserData } from '../providers/user-data';
 import { Notifications } from '../providers/notifications';
 
@@ -78,6 +79,11 @@ export class StockpileApp {
     this.nav.push(ViewAccountPage, {
       user: Object.assign({}, this.user)
     });
+  }
+
+  viewKits() {
+    this.menuCtrl.close();
+    this.nav.push(KitsPage);
   }
 
   logout() {

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -12,6 +12,9 @@
         <h3>{{user?.email}}</h3>
         <p>{{organization?.name}}</p>
       </button>
+      <button ion-item (click)="viewKits()">
+        Kits
+      </button>
       <button ion-item (click)="logout()">
         Logout
       </button>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,19 +12,23 @@ import { Toast } from '@ionic-native/toast';
 import { AuthHttp } from 'angular2-jwt';
 import { StockpileApp } from './app.component';
 
+import { AddKitItemPage } from '../pages/add-kit-item/add-kit-item';
 import { ChangePasswordPage } from '../pages/change-password/change-password';
 import { EditAccountPage } from '../pages/edit-account/edit-account';
 import { EditItemPage } from '../pages/edit-item/edit-item';
+import { EditKitPage } from '../pages/edit-kit/edit-kit';
 import { HomePage } from '../pages/home/home';
 import { InventoryFilterPage } from '../pages/inventory-filter/inventory-filter';
 import { InventoryPage } from '../pages/inventory/inventory';
 import { ItemFilterPage } from '../pages/item-filter/item-filter';
+import { KitsPage } from '../pages/kits/kits';
 import { LoginPage } from '../pages/login/login';
 import { RentalPage } from '../pages/rental/rental';
 import { RentalDetailsPage } from '../pages/rental-details/rental-details';
 import { TabsPage } from '../pages/tabs/tabs';
 import { ViewAccountPage } from '../pages/view-account/view-account';
 import { ViewItemPage } from '../pages/view-item/view-item';
+import { ViewKitPage } from '../pages/view-kit/view-kit';
 
 import { ApiUrl } from '../providers/api-url';
 import { InventoryData } from '../providers/inventory-data';
@@ -37,19 +41,23 @@ import { getAuthHttp, cloudSettings } from '../services/auth-http-helpers';
 @NgModule({
   declarations: [
     StockpileApp,
+    AddKitItemPage,
     ChangePasswordPage,
     EditAccountPage,
     EditItemPage,
+    EditKitPage,
     HomePage,
     InventoryFilterPage,
     InventoryPage,
     ItemFilterPage,
+    KitsPage,
     LoginPage,
     RentalPage,
     RentalDetailsPage,
     TabsPage,
     ViewAccountPage,
-    ViewItemPage
+    ViewItemPage,
+    ViewKitPage
   ],
   imports: [
     BrowserModule,
@@ -70,19 +78,23 @@ import { getAuthHttp, cloudSettings } from '../services/auth-http-helpers';
   bootstrap: [IonicApp],
   entryComponents: [
     StockpileApp,
+    AddKitItemPage,
     ChangePasswordPage,
     EditAccountPage,
     EditItemPage,
+    EditKitPage,
     HomePage,
     InventoryFilterPage,
     InventoryPage,
     ItemFilterPage,
+    KitsPage,
     LoginPage,
     RentalPage,
     RentalDetailsPage,
     TabsPage,
     ViewAccountPage,
-    ViewItemPage
+    ViewItemPage,
+    ViewKitPage
   ],
   providers: [
     { provide: ErrorHandler, useClass: RavenErrorHandler },

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -5,6 +5,7 @@ import { StockpileApp } from './app.component';
 import { LoginPage } from '../pages/login/login';
 import { TabsPage } from '../pages/tabs/tabs';
 import { ViewAccountPage } from '../pages/view-account/view-account';
+import { KitsPage } from '../pages/kits/kits';
 import { TestData } from '../test-data';
 
 let instance: any = null;
@@ -91,6 +92,14 @@ describe('Root Component', () => {
     instance.viewInfo();
     expect(instance.menuCtrl.close).toHaveBeenCalled();
     expect(instance.nav.push).toHaveBeenCalledWith(ViewAccountPage, { user: TestData.user });
+  });
+
+  it('pushes KitsPage on nav on viewKits()', () => {
+    spyOn(instance.menuCtrl, 'close');
+    spyOn(instance.nav, 'push');
+    instance.viewKits();
+    expect(instance.menuCtrl.close).toHaveBeenCalled();
+    expect(instance.nav.push).toHaveBeenCalledWith(KitsPage);
   });
 
   it('calls logout(), closes side menu and sets nav root to LoginPage', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,19 +16,24 @@ export class Links {
   public static user = '/user';
   public static organization = '/organization';
   public static password = '/password';
+  public static kit = '/kit';
 }
 
 export class Messages {
-  private static baseSingular = 'Item successfully ';
-  private static basePlural = 'Item(s) successfully ';
-  private static already = 'Item is already ';
-  public static itemAdded = `${Messages.baseSingular} added`;
-  public static itemEdited = `${Messages.baseSingular} edited`;
-  public static itemDeleted = `${Messages.baseSingular} deleted`;
-  public static itemsReturned = `${Messages.basePlural} returned`;
-  public static itemsRented = `${Messages.basePlural} rented`;
-  public static itemAlreadyAdded = `${Messages.already} added to the list`;
-  public static itemAlreadyRented = `${Messages.already} rented`;
+  private static itemBaseSingular = 'Item successfully ';
+  private static itemBasePlural = 'Item(s) successfully ';
+  private static kitBaseSingular = 'Kit successfully ';
+  private static itemAlready = 'Item is already ';
+  public static itemAdded = `${Messages.itemBaseSingular} added`;
+  public static itemEdited = `${Messages.itemBaseSingular} edited`;
+  public static itemDeleted = `${Messages.itemBaseSingular} deleted`;
+  public static kitAdded = `${Messages.kitBaseSingular} added`;
+  public static kitEdited = `${Messages.kitBaseSingular} edited`;
+  public static kitDeleted = `${Messages.kitBaseSingular} deleted`;
+  public static itemsReturned = `${Messages.itemBasePlural} returned`;
+  public static itemsRented = `${Messages.itemBasePlural} rented`;
+  public static itemAlreadyAdded = `${Messages.itemAlready} added to the list`;
+  public static itemAlreadyRented = `${Messages.itemAlready} rented`;
   public static itemNotRented = 'Item is not currently rented';
   public static userEdited = 'User successfully edited';
   public static passwordsDontMatch = 'Passwords don\'t match';

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -202,6 +202,8 @@ export class InventoryDataMock {
   categories = TestData.categories;
   category = TestData.category;
   status = TestData.status;
+  kits = TestData.kits;
+  kitItems = TestData.kitItems;
   resolve: boolean = true;
 
   public addItem(): any {
@@ -221,7 +223,7 @@ export class InventoryDataMock {
   }
 
   public deleteItem(): any {
-    return this.returnValue();
+    return this.returnValue(TestData.response);
   }
 
   public filterItems(): any {
@@ -229,11 +231,11 @@ export class InventoryDataMock {
   }
 
   public rent(): any {
-    return this.returnValue();
+    return this.returnValue(TestData.response);
   }
 
   public return(): any {
-    return this.returnValue();
+    return this.returnValue(TestData.response);
   }
 
   public getBrands(): any {
@@ -261,6 +263,34 @@ export class InventoryDataMock {
   }
 
   public addCategory(): any {
+    return this.returnValue(TestData.response);
+  }
+
+  public getKits() {
+    return this.returnValue(this.kits);
+  }
+
+  public getKitItems() {
+    return this.returnValue(this.kitItems);
+  }
+
+  public addKitItem() {
+    return this.returnValue(TestData.response);
+  }
+
+  public deleteKitItem() {
+    return this.returnValue(TestData.response);
+  }
+
+  public addKit() {
+    return this.returnValue(TestData.response);
+  }
+
+  public editKit() {
+    return this.returnValue(TestData.response);
+  }
+
+  public deleteKit() {
     return this.returnValue(TestData.response);
   }
 

--- a/src/pages/add-kit-item/add-kit-item.html
+++ b/src/pages/add-kit-item/add-kit-item.html
@@ -1,0 +1,23 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Add Item to Kit</ion-title>
+  </ion-navbar>
+</ion-header>
+
+<ion-content padding>
+  <form #itemForm="ngForm">
+		<ion-list>
+      <ion-item (click)="presentModal(allBrands, itemProperties.brand)">
+        <ion-label floating color="primary">Brand</ion-label>
+        <ion-input [ngModel]="item.brand" readonly required name="brand" #brand="ngModel"></ion-input>
+      </ion-item>
+
+      <ion-item [hidden]="!item.brandID" (click)="presentModal(filteredModels, itemProperties.model)">
+        <ion-label floating color="primary">Model</ion-label>
+        <ion-input [ngModel]="item.model" readonly required name="model" #model="ngModel"></ion-input>
+      </ion-item>
+		</ion-list>
+
+		<button ion-button (click)="onAdd(itemForm)" type="submit" block [disabled]="!itemForm.valid">Add</button>
+	</form>
+</ion-content>

--- a/src/pages/add-kit-item/add-kit-item.html
+++ b/src/pages/add-kit-item/add-kit-item.html
@@ -9,12 +9,12 @@
 		<ion-list>
       <ion-item (click)="presentModal(allBrands, itemProperties.brand)">
         <ion-label floating color="primary">Brand</ion-label>
-        <ion-input [ngModel]="item.brand" readonly required name="brand" #brand="ngModel"></ion-input>
+        <ion-input [ngModel]="kitItem.brand" readonly required name="brand" #brand="ngModel"></ion-input>
       </ion-item>
 
-      <ion-item [hidden]="!item.brandID" (click)="presentModal(filteredModels, itemProperties.model)">
+      <ion-item [hidden]="!kitItem.brandID" (click)="presentModal(filteredModels, itemProperties.model)">
         <ion-label floating color="primary">Model</ion-label>
-        <ion-input [ngModel]="item.model" readonly required name="model" #model="ngModel"></ion-input>
+        <ion-input [ngModel]="kitItem.model" readonly required name="model" #model="ngModel"></ion-input>
       </ion-item>
 		</ion-list>
 

--- a/src/pages/add-kit-item/add-kit-item.spec.ts
+++ b/src/pages/add-kit-item/add-kit-item.spec.ts
@@ -1,0 +1,125 @@
+import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
+import { TestUtils } from '../../test';
+import { TestData } from '../../test-data';
+import { Actions, ItemProperties, Messages } from '../../constants';
+
+import { AddKitItemPage } from './add-kit-item';
+import { ItemFilterPage } from '../item-filter/item-filter';
+
+let fixture: ComponentFixture<AddKitItemPage> = null;
+let instance: any = null;
+
+describe('AddKitItem Page', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([AddKitItemPage]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+    expect(fixture).toBeTruthy();
+  });
+
+  it('gets brands and models', fakeAsync(() => {
+    instance.inventoryData.brands = TestData.brands;
+    instance.inventoryData.models = TestData.models;
+    instance.ngOnInit();
+    tick();
+    expect(instance.allBrands).toEqual(TestData.brands.results);
+    expect(instance.allModels).toEqual(TestData.models.results);
+  }));
+
+  it('shows toast if error while getting brands, models and categories', fakeAsync(() => {
+    instance.inventoryData.resolve = false;
+    spyOn(instance.notifications, 'showToast');
+    instance.ngOnInit();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledTimes(2);
+  }));
+
+  it('pops nav onAdd()', () => {
+    spyOn(instance.events, 'publish');
+    spyOn(instance.navCtrl, 'pop');
+    instance.kitItem = TestData.kitItem;
+    instance.onAdd();
+    expect(instance.events.publish).toHaveBeenCalledWith('kit-item:added', TestData.kitItem);
+    expect(instance.navCtrl.pop).toHaveBeenCalled();
+  });
+
+  it('filter models on filterModels()', () => {
+    instance.allModels = TestData.models.results;
+    instance.kitItem.brandID = TestData.apiItem.brandID;
+    instance.filterModels();
+    expect(instance.filteredModels).toEqual(TestData.filteredModels);
+  });
+
+  it('creates a modal on presentModal()', () => {
+    spyOn(instance.modalCtrl, 'create').and.callThrough();
+    instance.presentModal(TestData.brands.results, ItemProperties.brand);
+    expect(instance.modalCtrl.create).toHaveBeenCalledWith(ItemFilterPage, { elements: TestData.brands.results, type: ItemProperties.brand });
+  });
+
+  it('creates a new brand on createElement', fakeAsync(() => {
+    instance.allBrands = TestData.brands.results;
+    const brandsResult = TestData.brands.results;
+    brandsResult.push(TestData.brand);
+    spyOn(instance.inventoryData, 'addBrand').and.callThrough();
+    spyOn(instance, 'assignElement');
+    instance.createElement(ItemProperties.brand, TestData.brand.name);
+    tick();
+    expect(instance.inventoryData.addBrand).toHaveBeenCalledWith(TestData.brand.name);
+    expect(instance.allBrands).toEqual(brandsResult);
+    expect(instance.assignElement).toHaveBeenCalledWith(ItemProperties.brand, TestData.brand);
+  }));
+
+  it('creates a new model on createElement', fakeAsync(() => {
+    instance.allModels = TestData.models.results;
+    instance.kitItem = TestData.kitItem;
+    const modelsResult = TestData.models.results;
+    modelsResult.push(TestData.model);
+    const newModel = { name: TestData.model.name, modelID: TestData.model.modelID };
+    spyOn(instance.inventoryData, 'addModel').and.callThrough();
+    spyOn(instance, 'assignElement');
+    instance.createElement(ItemProperties.model, TestData.model.name);
+    tick();
+    expect(instance.inventoryData.addModel).toHaveBeenCalledWith(TestData.model.name, TestData.kitItem.brandID);
+    expect(instance.allModels).toEqual(modelsResult);
+    expect(instance.assignElement).toHaveBeenCalledWith(ItemProperties.model, newModel);
+  }));
+
+  it('shows toast if error on createElement with brand', fakeAsync(() => {
+    instance.inventoryData.resolve = false;
+    spyOn(instance.notifications, 'showToast');
+    instance.createElement(ItemProperties.brand, TestData.brand.name);
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('shows toast if error on createElement with model', fakeAsync(() => {
+    instance.inventoryData.resolve = false;
+    instance.kitItem = TestData.kitItem;
+    spyOn(instance.notifications, 'showToast');
+    instance.createElement(ItemProperties.model, TestData.model.name);
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('assigns a brand', () => {
+    spyOn(instance, 'filterModels');
+    instance.assignElement(ItemProperties.brand, TestData.brand);
+    expect(instance.kitItem.brandID).toEqual(TestData.brand.brandID);
+    expect(instance.kitItem.brand).toEqual(TestData.brand.name);
+    expect(instance.filterModels).toHaveBeenCalled();
+  });
+
+  it('assigns a model', () => {
+    instance.assignElement(ItemProperties.model, TestData.model);
+    expect(instance.kitItem.modelID).toEqual(TestData.model.modelID);
+    expect(instance.kitItem.model).toEqual(TestData.model.name);
+  });
+});

--- a/src/pages/add-kit-item/add-kit-item.ts
+++ b/src/pages/add-kit-item/add-kit-item.ts
@@ -1,0 +1,120 @@
+import { Component } from '@angular/core';
+import { NavController, NavParams, ModalController, Events } from 'ionic-angular';
+
+import { InventoryData } from '../../providers/inventory-data';
+
+import { Actions, ItemProperties, Messages } from '../../constants';
+import { ItemFilterPage } from '../item-filter/item-filter';
+import { Notifications } from '../../providers/notifications';
+
+@Component({
+  selector: 'page-add-kit-item',
+  templateUrl: 'add-kit-item.html'
+})
+export class AddKitItemPage {
+  itemProperties = ItemProperties;
+  kitItem: {brandID?: number, brand?: string, modelID?: number, model?: string} = {};
+  allBrands;
+  allModels;
+  filteredModels;
+
+  constructor(
+    public navCtrl: NavController,
+    public navParams: NavParams,
+    public inventoryData: InventoryData,
+    public modalCtrl: ModalController,
+    public notifications: Notifications,
+    public events: Events
+  ) { }
+
+  ngOnInit() {
+    this.inventoryData.getBrands().subscribe(
+      (brands: any) => this.allBrands = brands.results,
+      err => this.notifications.showToast(err)
+    );
+
+    this.inventoryData.getModels().subscribe(
+      (models: any) => {
+        this.allModels = models.results;
+      },
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  onAdd() {
+    this.events.publish('kit-item:added', this.kitItem);
+    this.navCtrl.pop();
+  }
+
+  filterModels() {
+    this.filteredModels = this.allModels.filter((model) => {
+      return (model.brandID === this.kitItem.brandID);
+    });
+  }
+
+  presentModal(elements, type) {
+    let modal = this.modalCtrl.create(ItemFilterPage, {
+      elements: elements,
+      type: type
+    });
+
+    modal.onDidDismiss((element, isNew) => {
+      if (element) {
+        if (isNew) {
+          this.createElement(type, element);
+        } else {
+          this.assignElement(type, element);
+        }
+      }
+   });
+
+    modal.present();
+  }
+
+  createElement(type, element) {
+    switch (type) {
+      case ItemProperties.brand:
+        this.inventoryData.addBrand(element).subscribe(
+          (brand: any) => {
+            const newBrand = {
+              brandID: brand.id,
+              name: element
+            };
+
+            this.allBrands.push(newBrand);
+            this.assignElement(type, newBrand);
+          },
+          err => this.notifications.showToast(err)
+        );
+        break;
+      case ItemProperties.model:
+        this.inventoryData.addModel(element, this.kitItem.brandID).subscribe(
+          (model: any) => {
+            const newModel = {
+              modelID: model.id,
+              name: element
+            };
+
+            this.allModels.push(newModel);
+            this.assignElement(type, newModel);
+          },
+          err => this.notifications.showToast(err)
+        );
+        break;
+    }
+  }
+
+  assignElement(type, element) {
+    switch (type) {
+      case ItemProperties.brand:
+        this.kitItem.brand = element.name;
+        this.kitItem.brandID = element.brandID;
+        this.filterModels();
+        break;
+      case ItemProperties.model:
+        this.kitItem.model = element.name;
+        this.kitItem.modelID = element.modelID;
+        break;
+    }
+  }
+}

--- a/src/pages/add-kit-item/add-kit-item.ts
+++ b/src/pages/add-kit-item/add-kit-item.ts
@@ -53,10 +53,7 @@ export class AddKitItemPage {
   }
 
   presentModal(elements, type) {
-    let modal = this.modalCtrl.create(ItemFilterPage, {
-      elements: elements,
-      type: type
-    });
+    let modal = this.modalCtrl.create(ItemFilterPage, { elements, type });
 
     modal.onDidDismiss((element, isNew) => {
       if (element) {

--- a/src/pages/edit-kit/edit-kit.html
+++ b/src/pages/edit-kit/edit-kit.html
@@ -1,0 +1,36 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>{{ action }} kit</ion-title>
+    <ion-buttons *ngIf="action === actions.edit" end>
+      <button ion-button icon-only (click)="onDelete()">
+        <ion-icon name="trash"></ion-icon>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+
+<ion-content padding>
+  <form #kitForm="ngForm">
+		<ion-list>
+      <ion-item>
+        <ion-label floating color="primary">Name</ion-label>
+        <ion-input [(ngModel)]="kit.name" required name="name" #name="ngModel"></ion-input>
+      </ion-item>
+
+      <ion-list-header>Items</ion-list-header>
+      <ion-item *ngFor="let kitItem of kitItems; let i = index">
+        {{ kitItem.brand }} {{ kitItem.model }}
+        <button ion-button clear item-right color="dark" (click)="onRemoveKitItem(i, kitItem)">
+          <ion-icon name="close"></ion-icon>
+        </button>
+      </ion-item>
+
+      <ion-item *ngIf="!kitItems.length">
+        No items found
+      </ion-item>
+		</ion-list>
+
+    <button ion-button (click)="addItem()" block outline>Add Item to Kit</button>
+		<button ion-button (click)="onSave(kitForm)" type="submit" block [disabled]="!kitForm.valid">Save</button>
+	</form>
+</ion-content>

--- a/src/pages/edit-kit/edit-kit.spec.ts
+++ b/src/pages/edit-kit/edit-kit.spec.ts
@@ -1,0 +1,154 @@
+import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
+import { TestUtils } from '../../test';
+import { TestData } from '../../test-data';
+import { Actions, Messages } from '../../constants';
+
+import { EditKitPage } from './edit-kit';
+import { AddKitItemPage } from '../add-kit-item/add-kit-item';
+
+let fixture: ComponentFixture<EditKitPage> = null;
+let instance: any = null;
+
+describe('EditKit Page', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([EditKitPage]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+    expect(fixture).toBeTruthy();
+  });
+
+  it('gets navParam action', () => {
+    instance.navParams.param = Actions.add;
+    instance.ngOnInit();
+    expect(instance.action).toEqual(Actions.add);
+  });
+
+  it('adds a kitItem if event \'kit-item:added\' is published', () => {
+    instance.navParams.param = Actions.edit;
+    instance.ngOnInit();
+    instance.kitItems = TestData.kitItems.results;
+    instance.events.publish('kit-item:added', TestData.kitItem);
+    expect(instance.kitItems).toEqual(TestData.addedKitItems.results);
+    expect(instance.modelsToCreate).toEqual([TestData.kitItem.modelID]);
+  });
+
+  it('adds kit onSave() if action is add', fakeAsync(() => {
+    instance.action = Actions.add;
+    instance.kit = TestData.kit;
+    spyOn(instance.inventoryData, 'addKit').and.callThrough();
+    spyOn(instance ,'saveKitItems');
+    instance.onSave();
+    tick();
+    expect(instance.inventoryData.addKit).toHaveBeenCalledWith(TestData.kit.name);
+    expect(instance.saveKitItems).toHaveBeenCalledWith(TestData.response, Messages.kitAdded, 'kit:added');
+  }));
+
+  it('edits kit onSave() if action is edit', fakeAsync(() => {
+    instance.action = Actions.edit;
+    instance.kit = TestData.kit;
+    spyOn(instance.inventoryData, 'editKit').and.callThrough();
+    spyOn(instance ,'saveKitItems');
+    instance.onSave();
+    tick();
+    expect(instance.inventoryData.editKit).toHaveBeenCalledWith(TestData.kit);
+    expect(instance.saveKitItems).toHaveBeenCalledWith(TestData.response, Messages.kitEdited, 'kit:edited');
+  }));
+
+  it('shows toast if error onSave()', fakeAsync(() => {
+    instance.action = Actions.add;
+    instance.kit = TestData.kit;
+    instance.inventoryData.resolve = false;
+    spyOn(instance.notifications, 'showToast');
+    instance.onSave();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('adds kitItems on saveKitItems() if action is add', fakeAsync(() => {
+    spyOn(instance.inventoryData, 'addKitItem').and.callThrough();
+    spyOn(instance.events, 'publish');
+    spyOn(instance.navCtrl, 'pop');
+    spyOn(instance.notifications, 'showToast');
+    instance.kit = TestData.kit;
+    instance.action = Actions.add;
+    instance.kitItems = TestData.kitItems.results;
+    instance.saveKitItems(TestData.kit, Messages.kitAdded, 'kit:added');
+    tick();
+    expect(instance.inventoryData.addKitItem).toHaveBeenCalledTimes(TestData.kitItems.results.length);
+    expect(instance.events.publish).toHaveBeenCalledWith('kit:added', TestData.kit);
+    expect(instance.navCtrl.pop).toHaveBeenCalled();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(Messages.kitAdded);
+  }));
+
+  it('edits kitItems on saveKitItems() if action is edit', fakeAsync(() => {
+    spyOn(instance.inventoryData, 'addKitItem').and.callThrough();
+    spyOn(instance.inventoryData, 'deleteKitItem').and.callThrough();
+    spyOn(instance.events, 'publish');
+    spyOn(instance.navCtrl, 'pop');
+    spyOn(instance.notifications, 'showToast');
+    instance.kit = TestData.kit;
+    instance.action = Actions.edit;
+    instance.modelsToCreate = TestData.modelsToCreate;
+    instance.modelsToDelete = TestData.modelsToDelete;
+    instance.saveKitItems(TestData.kit, Messages.kitEdited, 'kit:edited');
+    tick();
+    expect(instance.inventoryData.addKitItem).toHaveBeenCalledTimes(TestData.modelsToCreate.length);
+    expect(instance.inventoryData.deleteKitItem).toHaveBeenCalledTimes(TestData.modelsToDelete.length);
+    expect(instance.events.publish).toHaveBeenCalledWith('kit:edited', TestData.kit);
+    expect(instance.navCtrl.pop).toHaveBeenCalled();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(Messages.kitEdited);
+  }));
+
+  it('shows toast if error on saveKitItems()', fakeAsync(() => {
+    spyOn(instance.notifications, 'showToast');
+    instance.kit = TestData.kit;
+    instance.action = Actions.add;
+    instance.kitItems = TestData.kitItems.results;
+    instance.inventoryData.resolve = false;
+    instance.saveKitItems(TestData.kit, Messages.kitAdded, 'kit:added');
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('deletes kit onDelete()', fakeAsync(() => {
+    spyOn(instance.inventoryData, 'deleteKit').and.callThrough();
+    spyOn(instance.notifications, 'showToast');
+    spyOn(instance.events, 'publish');
+    spyOn(instance.navCtrl, 'pop');
+    instance.kit = TestData.kit;
+    instance.onDelete();
+    tick();
+    expect(instance.inventoryData.deleteKit).toHaveBeenCalledWith(TestData.kit.kitID);
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(Messages.kitDeleted);
+    expect(instance.events.publish).toHaveBeenCalledWith('kit:deleted', TestData.kit);
+    expect(instance.navCtrl.pop).toHaveBeenCalled();
+  }));
+
+  it('shows toast if error onDelete()', fakeAsync(() => {
+    instance.inventoryData.resolve = false;
+    spyOn(instance.notifications, 'showToast');
+    instance.onDelete();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('pushes AddKitItemPage on addItem()', () => {
+    spyOn(instance.navCtrl, 'push');
+    instance.addItem();
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(AddKitItemPage);
+  });
+
+  it('adds modelID to modelsToDelete onRemoveKitItem()', () => {
+    instance.kitItems = TestData.kitItems.results;
+    instance.onRemoveKitItem(0, TestData.kitItem);
+    expect(instance.modelsToDelete).toEqual([TestData.kitItem.modelID]);
+  });
+});

--- a/src/pages/edit-kit/edit-kit.ts
+++ b/src/pages/edit-kit/edit-kit.ts
@@ -1,0 +1,117 @@
+import { Component } from '@angular/core';
+import { NavController, NavParams, ModalController, Events } from 'ionic-angular';
+
+import { InventoryData } from '../../providers/inventory-data';
+import { AddKitItemPage } from '../add-kit-item/add-kit-item';
+
+import { Actions, ItemProperties, Messages } from '../../constants';
+import { ItemFilterPage } from '../item-filter/item-filter';
+import { Notifications } from '../../providers/notifications';
+
+@Component({
+  selector: 'page-edit-kit',
+  templateUrl: 'edit-kit.html'
+})
+export class EditKitPage {
+  actions = Actions;
+  action: Actions = '';
+  kit: { kitID?: number, name?: string } = {};
+  kitItems = [];
+  modelsToDelete = [];
+  modelsToCreate = [];
+
+  constructor(
+    public navCtrl: NavController,
+    public navParams: NavParams,
+    public inventoryData: InventoryData,
+    public notifications: Notifications,
+    public modalCtrl: ModalController,
+    public events: Events
+  ) { }
+
+  ngOnInit() {
+    this.action = this.navParams.get('action');
+
+    if (this.action === this.actions.edit) {
+      this.kit = this.navParams.get('kit');
+      this.kitItems = this.navParams.get('kitItems');
+    }
+
+    this.events.subscribe('kit-item:added', kitItem => {
+      this.kitItems.push(kitItem);
+      this.modelsToCreate.push(kitItem.modelID);
+    });
+  }
+
+  onSave() {
+    let apiCall;
+    let message;
+    let event;
+
+    if (this.action === this.actions.add) {
+      apiCall = this.inventoryData.addKit(this.kit.name);
+      message = Messages.kitAdded;
+      event = 'kit:added';
+    } else {
+      apiCall = this.inventoryData.editKit(this.kit);
+      message = Messages.kitEdited;
+      event = 'kit:edited';
+    }
+
+    apiCall.subscribe(
+      kit => {
+        this.saveKitItems(kit, message, event)
+      },
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  private saveKitItems(kit, message: string, event: string) {
+    let models = [];
+
+    if (this.action === Actions.add) {
+      this.kit.kitID = kit.id;
+
+      for (const kitItem of this.kitItems) {
+        models.push(this.inventoryData.addKitItem(this.kit.kitID, kitItem.modelID).toPromise());
+      }
+    } else {
+      for (const modelID of this.modelsToDelete) {
+        models.push(this.inventoryData.deleteKitItem(this.kit.kitID, modelID).toPromise());
+      }
+
+      for (const modelID of this.modelsToCreate) {
+        models.push(this.inventoryData.addKitItem(this.kit.kitID, modelID).toPromise());
+      }
+    }
+
+    Promise.all(models).then(
+      success => {
+        this.notifications.showToast(message);
+        this.events.publish(event, this.kit);
+        this.navCtrl.pop();
+      },
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  onDelete() {
+    this.inventoryData.deleteKit(this.kit.kitID).subscribe(
+      success => {
+        this.notifications.showToast(Messages.kitDeleted);
+        this.events.publish('kit:deleted', this.kit);
+        this.navCtrl.pop();
+      },
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  addItem() {
+    this.navCtrl.push(AddKitItemPage);
+  }
+
+  onRemoveKitItem(index, kitItem) {
+    this.modelsToDelete.push(kitItem.modelID);
+    this.kitItems.splice(index, 1);
+  }
+}

--- a/src/pages/kits/kits.html
+++ b/src/pages/kits/kits.html
@@ -1,0 +1,27 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Kits</ion-title>
+    <ion-buttons end>
+      <button ion-button icon-only (click)="onAdd()">
+        <ion-icon name="add"></ion-icon>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+
+<ion-content padding>
+  <ion-list>
+    <ion-list-header>Kits</ion-list-header>
+    <button ion-item *ngFor="let kit of kits" (click)="viewKit(kit)">
+      <h2>{{ kit.name }}</h2>
+    </button>
+
+    <ion-item *ngIf="!kits.length">
+      No kits found
+    </ion-item>
+  </ion-list>
+
+  <ion-infinite-scroll (ionInfinite)="$event.waitFor(loadKits())" [enabled]="loadMoreItems">
+    <ion-infinite-scroll-content></ion-infinite-scroll-content>
+  </ion-infinite-scroll>
+</ion-content>

--- a/src/pages/kits/kits.spec.ts
+++ b/src/pages/kits/kits.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
+import { TestUtils } from '../../test';
+import { TestData } from '../../test-data';
+import { Actions } from '../../constants';
+
+import { KitsPage } from './kits';
+import { ViewKitPage } from '../view-kit/view-kit';
+import { EditKitPage } from '../edit-kit/edit-kit';
+
+let fixture: ComponentFixture<KitsPage> = null;
+let instance: any = null;
+
+describe('Kits Page', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([KitsPage]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+    expect(fixture).toBeTruthy();
+  });
+
+  it('gets kits in ngOnInit', fakeAsync(() => {
+    instance.inventoryData.kits = TestData.kits;
+    instance.ngOnInit();
+    tick();
+    expect(instance.kits).toEqual(TestData.kits.results);
+  }));
+
+  it('gets kits on loadKits()', fakeAsync(() => {
+    spyOn(instance.inventoryData, 'getKits').and.callThrough();
+    instance.loadKits();
+    tick();
+    expect(instance.kits).toEqual(TestData.kits.results);
+  }));
+
+  it('sets loadMoreItems to false if not kits returned in loadKits()', fakeAsync(() => {
+    instance.inventoryData.kits = { results: [] };
+    instance.loadMoreItems = true;
+    instance.loadKits();
+    tick();
+    expect(instance.loadMoreItems).toEqual(false);
+  }));
+
+  it('shows toast if error on loadKits()', fakeAsync(() => {
+    spyOn(instance.notifications, 'showToast');
+    instance.inventoryData.resolve = false;
+    instance.loadKits();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('pushes ViewKitPage on nav on viewKit()', () => {
+    spyOn(instance.navCtrl, 'push');
+    instance.viewKit(TestData.kit);
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(ViewKitPage, { kit: TestData.kit });
+  });
+
+  it('pushes EditKitPage on nav on onAdd()', () => {
+    spyOn(instance.navCtrl, 'push');
+    instance.onAdd();
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(EditKitPage, { action: Actions.add });
+  });
+});

--- a/src/pages/kits/kits.ts
+++ b/src/pages/kits/kits.ts
@@ -1,0 +1,83 @@
+import { Component } from '@angular/core';
+import { NavController, Events } from 'ionic-angular';
+
+import { InventoryData } from '../../providers/inventory-data';
+import { Notifications } from '../../providers/notifications';
+import { Actions, paginationLimit } from '../../constants';
+import { EditKitPage } from '../edit-kit/edit-kit';
+import { ViewKitPage } from '../view-kit/view-kit';
+
+@Component({
+  selector: 'page-kits',
+  templateUrl: 'kits.html'
+})
+export class KitsPage {
+  kits = [];
+  loadMoreItems = true;
+  offset;
+
+  constructor(
+    public navCtrl: NavController,
+    public inventoryData: InventoryData,
+    public notifications: Notifications,
+    public events: Events
+  ) { }
+
+  ngOnInit() {
+    this.loadKits();
+
+    this.events.subscribe('kit:edited', kit => {
+      const index = this.kits.findIndex(element => element.kitID === kit.kitID);
+      this.kits.splice(index, 1, kit);
+    });
+
+    this.events.subscribe('kit:added', kit => {
+      this.kits.push(kit);
+    });
+
+    this.events.subscribe('kit:deleted', kit => {
+      const index = this.kits.findIndex(element => element.kitID === kit.kitID);
+      this.kits.splice(index, 1);
+    });
+  }
+
+ /**
+  * Gets all kits and resolves a promise when done for the infinite scroll
+  * component.
+  */
+  loadKits() {
+    return new Promise(resolve => {
+      this.inventoryData.getKits(
+        paginationLimit,
+        this.offset
+      ).subscribe(
+        (kits: any) => {
+          kits.results.forEach(kit => {
+            this.kits.push(kit);
+          });
+
+          if (!kits.results.length) {
+            this.loadMoreItems = false;
+          } else {
+            this.offset += paginationLimit;
+          }
+
+          resolve();
+        },
+        err => this.notifications.showToast(err)
+      );
+    });
+  }
+
+  viewKit(kit) {
+    this.navCtrl.push(ViewKitPage, {
+      kit: kit
+    });
+  }
+
+  onAdd() {
+    this.navCtrl.push(EditKitPage, {
+      action: Actions.add
+    });
+  }
+}

--- a/src/pages/view-kit/view-kit.html
+++ b/src/pages/view-kit/view-kit.html
@@ -17,7 +17,7 @@
   <ion-list>
     <ion-list-header>Items</ion-list-header>
     <ion-item *ngFor="let kitItem of kitItems">
-      <h2>{{ kitItem.brand }} {{ kitItems.model }}</h2>
+      <h2>{{ kitItem.brand }} {{ kitItem.model }}</h2>
     </ion-item>
 
     <ion-item *ngIf="!kitItems.length">

--- a/src/pages/view-kit/view-kit.html
+++ b/src/pages/view-kit/view-kit.html
@@ -1,0 +1,31 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Kit</ion-title>
+    <ion-buttons *ngIf="platform.is('ios')" end>
+      <button ion-button clear (click)="editKit()">
+        Edit
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+
+<ion-content padding>
+	<ion-list>
+    <ion-item>{{kit?.name}}</ion-item>
+	</ion-list>
+
+  <ion-list>
+    <ion-list-header>Items</ion-list-header>
+    <ion-item *ngFor="let kitItem of kitItems">
+      <h2>{{ kitItem.brand }} {{ kitItems.model }}</h2>
+    </ion-item>
+
+    <ion-item *ngIf="!kitItems.length">
+      No items found
+    </ion-item>
+  </ion-list>
+
+  <ion-fab right bottom *ngIf="platform.is('android')">
+    <button ion-fab color="secondary" (click)="editKit()"><ion-icon name="create"></ion-icon></button>
+  </ion-fab>
+</ion-content>

--- a/src/pages/view-kit/view-kit.spec.ts
+++ b/src/pages/view-kit/view-kit.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
+import { TestUtils } from '../../test';
+import { TestData } from '../../test-data';
+import { Actions } from '../../constants';
+
+import { ViewKitPage } from './view-kit';
+import { EditKitPage } from '../edit-kit/edit-kit';
+
+let fixture: ComponentFixture<ViewKitPage> = null;
+let instance: any = null;
+
+describe('ViewKit Page', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([ViewKitPage]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+    expect(fixture).toBeTruthy();
+  });
+
+  it('gets kit and kitItems in ngOnInit', fakeAsync(() => {
+    instance.navParams.param = TestData.kit;
+    instance.inventoryData.kitItems = TestData.kitItems;
+    instance.ngOnInit();
+    tick();
+    expect(instance.kit).toEqual(TestData.kit);
+    expect(instance.kitItems).toEqual(TestData.kitItems.results);
+  }));
+
+  it('gets kitItems when event \'kit:edited\' is published', fakeAsync(() => {
+    instance.navParams.param = TestData.kit;
+    instance.inventoryData.kitItems = TestData.kitItems;
+    instance.ngOnInit();
+    tick();
+    instance.kitItems = [];
+    instance.events.publish('kit:edited', TestData.kit);
+    tick();
+    expect(instance.kitItems).toEqual(TestData.kitItems.results);
+  }));
+
+  it('shows toast is error in getting kitItems', fakeAsync(() => {
+    instance.inventoryData.resolve = false;
+    instance.navParams.param = TestData.kit;
+    spyOn(instance.notifications, 'showToast');
+    instance.ngOnInit();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('pushes EditKitPage on nav on editKit()', () => {
+    instance.kit = TestData.kit;
+    instance.kitItems = TestData.kitItems;
+    spyOn(instance.navCtrl, 'push');
+    instance.editKit();
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(EditKitPage, { kit: TestData.kit, kitItems: TestData.kitItems, action: Actions.edit });
+  });
+});

--- a/src/pages/view-kit/view-kit.ts
+++ b/src/pages/view-kit/view-kit.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+import { NavController, NavParams, Platform, Events } from 'ionic-angular';
+
+import { Actions } from '../../constants';
+import { EditKitPage } from '../edit-kit/edit-kit';
+import { InventoryData } from '../../providers/inventory-data';
+import { Notifications } from '../../providers/notifications';
+
+@Component({
+  selector: 'page-view-kit',
+  templateUrl: 'view-kit.html'
+})
+export class ViewKitPage {
+  kit;
+  kitItems = [];
+
+  constructor(
+    public navCtrl: NavController,
+    public navParams: NavParams,
+    public platform: Platform,
+    public notifications: Notifications,
+    public inventoryData: InventoryData,
+    public events: Events
+  ) { }
+
+  ngOnInit() {
+    this.kit = this.navParams.get('kit');
+    this.getKitItems();
+
+    this.events.subscribe('kit:edited', () => {
+      this.getKitItems();
+    });
+  }
+
+  private getKitItems() {
+    this.inventoryData.getKitItems(this.kit.kitID).subscribe(
+      kitItems => this.kitItems = kitItems.results,
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  editKit() {
+    this.navCtrl.push(EditKitPage, {
+      kit: this.kit,
+      kitItems: this.kitItems,
+      action: Actions.edit
+    });
+  }
+}

--- a/src/providers/inventory-data.spec.ts
+++ b/src/providers/inventory-data.spec.ts
@@ -178,6 +178,83 @@ describe('InventoryData Provider', () => {
     );
   })));
 
+  it('returns kits on getKits()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.kits) })))
+    );
+    tick();
+    inventoryData.getKits().subscribe(
+      res => expect(res).toEqual(TestData.kits),
+      err => fail(err)
+    );
+  })));
+
+  it('returns kitItems on getKitItems()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.kitItems) })))
+    );
+    tick();
+    inventoryData.getKitItems(TestData.kit.kitID).subscribe(
+      res => expect(res).toEqual(TestData.kitItems),
+      err => fail(err)
+    );
+  })));
+
+  it('returns a message on addKitItem()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
+    );
+    tick();
+    inventoryData.addKitItem(TestData.kit.kitID, TestData.kitItem.modelID).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  })));
+
+  it('returns a message on deleteKitItem()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
+    );
+    tick();
+    inventoryData.deleteKitItem(TestData.kit.kitID, TestData.kitItem.modelID).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  })));
+
+  it('returns a message on addKit()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
+    );
+    tick();
+    inventoryData.addKit(TestData.kit.name).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  })));
+
+  it('returns a message on editKit()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
+    );
+    tick();
+    inventoryData.editKit(TestData.kit).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  })));
+
+  it('returns a message on deleteKit()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
+    );
+    tick();
+    inventoryData.deleteKit(TestData.kit.kitID).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  })));
+
   it('returns an error message if error on putEndpoint', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
     mockBackend.connections.subscribe(
       conn => conn.mockError(new Response(new ResponseOptions({ body: { message: TestData.error } })))

--- a/src/providers/inventory-data.ts
+++ b/src/providers/inventory-data.ts
@@ -107,6 +107,54 @@ export class InventoryData {
     return this.putEndpoint(Links.category, body);
   }
 
+  getKits(limit?: number, offset?: number) {
+    let params: URLSearchParams = new URLSearchParams();
+
+    if (limit) {
+      params.set('limit', limit.toString());
+    }
+
+    if (offset) {
+      params.set('offset', offset.toString());
+    }
+
+    return this.getEndpoint(Links.kit, {
+      search: params
+    });
+  }
+
+  getKitItems(kitID: number) {
+    return this.getEndpoint(`${Links.kit}/${kitID}${Links.model}`);
+  }
+
+  addKitItem(kitID: number, modelID: number) {
+    const body = {
+      modelID
+    };
+
+    return this.putEndpoint(`${Links.kit}/${kitID}${Links.model}`, body);
+  }
+
+  deleteKitItem(kitID: number, modelID: number) {
+    return this.deleteEndpoint(`${Links.kit}/${kitID}${Links.model}/${modelID}`);
+  }
+
+  addKit(kitName: string) {
+    const body = {
+      name: kitName
+    };
+
+    return this.putEndpoint(Links.kit, body);
+  }
+
+  editKit(kit) {
+    return this.putEndpoint(`${Links.kit}/${kit.kitID}`, kit);
+  }
+
+  deleteKit(kitID: number) {
+    return this.deleteEndpoint(`${Links.kit}/${kitID}`);
+  }
+
   private getEndpoint(endpoint: string, params?: Object) {
     return this.authHttp.get(`${this.apiUrl.getUrl()}${endpoint}`, params)
       .map(extractData)

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -247,4 +247,78 @@ export class TestData {
     userID: 74,
     organizationID: 539
   };
+
+  public static kits = {
+    results: [
+      { kitID: 1, name: 'Canon T5i', organizationID: 4 },
+      { kitID: 2, name: 'Shure SM 58', organizationID: 5 },
+      { kitID: 3, name: 'Sennheiser e609', organizationID: 6 }
+    ]
+  };
+
+  public static kit = {
+    kitID: 1,
+    name: 'Canon T7i',
+    organizationID: 4
+  };
+
+  public static updatedKits = {
+    results: [
+      { kitID: 1, name: 'Canon T7i', organizationID: 4 },
+      { kitID: 2, name: 'Shure SM 58', organizationID: 5 },
+      { kitID: 3, name: 'Sennheiser e609', organizationID: 6 }
+    ]
+  };
+
+  public static addedKits = {
+    results: [
+      { kitID: 1, name: 'Canon T5i', organizationID: 4 },
+      { kitID: 2, name: 'Shure SM 58', organizationID: 5 },
+      { kitID: 3, name: 'Sennheiser e609', organizationID: 6 },
+      { kitID: 1, name: 'Canon T7i', organizationID: 4 }
+    ]
+  };
+
+  public static deletedKits = {
+    results: [
+      { kitID: 2, name: 'Shure SM 58', organizationID: 5 },
+      { kitID: 3, name: 'Sennheiser e609', organizationID: 6 }
+    ]
+  };
+
+  public static kitItems = {
+    results: [
+      { kitID: 1, modelID: 2, model: 'T5i', brandID: 3, brand: 'Canon' },
+      { kitID: 1, modelID: 4, model: 'SM58', brandID: 5, brand: 'Shure' },
+      { kitID: 1, modelID: 6, model: 'e609', brandID: 7, brand: 'Sennheiser' }
+    ]
+  };
+
+  public static addedKitItems = {
+    results: [
+      { kitID: 1, modelID: 2, model: 'T5i', brandID: 3, brand: 'Canon' },
+      { kitID: 1, modelID: 4, model: 'SM58', brandID: 5, brand: 'Shure' },
+      { kitID: 1, modelID: 6, model: 'e609', brandID: 7, brand: 'Sennheiser' },
+      { kitID: 1, modelID: 2, model: 'T5i', brandID: 3, brand: 'Canon' }
+    ]
+  };
+
+  public static deletedKitItems = {
+    results: [
+      { kitID: 1, modelID: 4, model: 'SM58', brandID: 5, brand: 'Shure' },
+      { kitID: 1, modelID: 6, model: 'e609', brandID: 7, brand: 'Sennheiser' }
+    ]
+  };
+
+  public static kitItem = {
+    kitID: 1,
+    modelID: 2,
+    model: 'T5i',
+    brandID: 3,
+    brand: 'Canon'
+  };
+
+  public static modelsToDelete = [1, 2, 3, 4];
+
+  public static modelsToCreate = [5, 6, 7];
 }


### PR DESCRIPTION
Closes #240 

This simply adds the ability to manage kits. [This issue](#163) will add the ability to use them to rent items.

This caused quite a lot of code duplication/copy and pasting. I created [an issue](#237) to investigate potential solutions, but I feel like Angular's object oriented approach might not allow for the abstraction of page creation (which is where most of the code duplication happens with this PR).

Here are a few screenshots of what it looks like:

<img width="758" alt="screen shot 2017-05-01 at 11 39 30 am" src="https://cloud.githubusercontent.com/assets/12487270/25584169/f4a7928e-2e62-11e7-8496-de24ea8b6d60.png">
<img width="750" alt="screen shot 2017-05-01 at 11 39 41 am" src="https://cloud.githubusercontent.com/assets/12487270/25584171/f4acee50-2e62-11e7-840c-651fde24cc98.png">
<img width="744" alt="screen shot 2017-05-01 at 11 39 49 am" src="https://cloud.githubusercontent.com/assets/12487270/25584170/f4ab8998-2e62-11e7-9879-1248f2f9fae7.png">


