### PR TITLE
Change itemID type to number

### DIFF
--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -11,7 +11,7 @@ import { Messages } from '../../constants';
 })
 export class RentalDetailsPage {
   items = [];
-  details: {itemID?: string, startDate?: string, endDate?: string} = {};
+  details: {itemID?: number, startDate?: string, endDate?: string} = {};
 
   constructor(
     public navCtrl: NavController,


### PR DESCRIPTION
Closes #238 

There actually was only one place where an ID was declared as string, so changing it to number made more sense.