### PR TITLE
Add loading when waiting on the api

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -15,6 +15,9 @@
 // for the .md, .ios, or .wp mode classes. The mode class is
 // automatically applied to the <body> element in the app.
 
-.tag-button {
-  margin-top: 1em;
+ion-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -192,6 +192,16 @@ export class ModalMock {
   public present(): any {}
 }
 
+export class LoadingMock {
+  public create(): any {
+    return new LoadingMock;
+  }
+
+  public dismiss(): any {}
+
+  public present(): any {}
+}
+
 export class ViewMock {
   public dismiss(): any {}
 }

--- a/src/pages/change-password/change-password.ts
+++ b/src/pages/change-password/change-password.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController } from 'ionic-angular';
+import { NavController, LoadingController } from 'ionic-angular';
 
 import { UserData } from '../../providers/user-data';
 import { Notifications } from '../../providers/notifications';
@@ -15,7 +15,8 @@ export class ChangePasswordPage {
   constructor(
     public navCtrl: NavController,
     public userData: UserData,
-    public notifications: Notifications
+    public notifications: Notifications,
+    public loadingCtrl: LoadingController
   ) { }
 
   /**
@@ -24,12 +25,19 @@ export class ChangePasswordPage {
    */
   onSave() {
     if (this.passwords.newPassword === this.passwords.confirmPassword) {
+      let loading = this.loadingCtrl.create({
+        content: 'Changing your password, please wait...'
+      });
+
+      loading.present();
+
       this.userData.changePassword(this.passwords.currentPassword, this.passwords.newPassword).subscribe(
         data => {
           this.notifications.showToast(data.message);
           this.navCtrl.pop();
         },
-        err => this.notifications.showToast(err)
+        err => this.notifications.showToast(err),
+        () => loading.dismiss()
       );
     } else {
       this.notifications.showToast(Messages.passwordsDontMatch);

--- a/src/pages/edit-account/edit-account.ts
+++ b/src/pages/edit-account/edit-account.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams, Events } from 'ionic-angular';
+import { NavController, NavParams, Events, LoadingController } from 'ionic-angular';
 
 import { UserData } from '../../providers/user-data';
 import { Notifications } from '../../providers/notifications';
@@ -17,7 +17,8 @@ export class EditAccountPage {
     public navParams: NavParams,
     public events: Events,
     public userData: UserData,
-    public notifications: Notifications
+    public notifications: Notifications,
+    public loadingCtrl: LoadingController
   ) { }
 
   /**
@@ -31,13 +32,20 @@ export class EditAccountPage {
    * Calls the api to edit the user's info then pops nav.
    */
   onSave() {
+    let loading = this.loadingCtrl.create({
+      content: 'Saving changes, please wait...'
+    });
+
+    loading.present();
+
     this.userData.editUser(this.user).subscribe(
       data => {
         this.notifications.showToast(Messages.userEdited);
         this.events.publish('user:edited', data);
         this.navCtrl.pop();
       },
-      err => this.notifications.showToast(err)
+      err => this.notifications.showToast(err),
+      () => loading.dismiss()
     );
   }
 }

--- a/src/pages/edit-item/edit-item.ts
+++ b/src/pages/edit-item/edit-item.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams, ModalController, Events } from 'ionic-angular';
+import { NavController, NavParams, ModalController, Events, LoadingController } from 'ionic-angular';
 
 import { ItemPropertyData } from '../../providers/item-property-data';
 import { ItemData } from '../../providers/item-data';
@@ -33,7 +33,8 @@ export class EditItemPage {
     public itemData: ItemData,
     public modalCtrl: ModalController,
     public notifications: Notifications,
-    public events: Events
+    public events: Events,
+    public loadingCtrl: LoadingController
   ) { }
 
   /**
@@ -96,13 +97,20 @@ export class EditItemPage {
       event = 'item:edited';
     }
 
+    let loading = this.loadingCtrl.create({
+      content: 'Saving changes, please wait...'
+    });
+
+    loading.present();
+
     apiCall.subscribe(
       item => {
         this.notifications.showToast(message);
         this.events.publish(event, item.barcode);
         this.navCtrl.pop();
       },
-      err => this.notifications.showToast(err)
+      err => this.notifications.showToast(err),
+      () => loading.dismiss()
     );
   }
 

--- a/src/pages/edit-kit/edit-kit.ts
+++ b/src/pages/edit-kit/edit-kit.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams, ModalController, Events } from 'ionic-angular';
+import { NavController, NavParams, ModalController, Events, LoadingController } from 'ionic-angular';
 
 import { KitData } from '../../providers/kit-data';
 import { AddKitItemPage } from '../add-kit-item/add-kit-item';
@@ -25,7 +25,8 @@ export class EditKitPage {
     public kitData: KitData,
     public notifications: Notifications,
     public modalCtrl: ModalController,
-    public events: Events
+    public events: Events,
+    public loadingCtrl: LoadingController
   ) { }
 
   /**
@@ -64,9 +65,16 @@ export class EditKitPage {
       event = 'kit:edited';
     }
 
+    let loading = this.loadingCtrl.create({
+      content: 'Saving changes, please wait...'
+    });
+
+    loading.present();
+
     apiCall.subscribe(
       kit => this.saveKitItems(kit, message, event),
-      err => this.notifications.showToast(err)
+      err => this.notifications.showToast(err),
+      () => loading.dismiss()
     );
   }
 

--- a/src/pages/inventory/inventory.html
+++ b/src/pages/inventory/inventory.html
@@ -31,9 +31,11 @@
       <h2>{{ item.brand }} {{ item.model }}</h2>
     </button>
 
-    <ion-item *ngIf="!items">
+    <ion-item *ngIf="!items.length && !loading">
       No items found
     </ion-item>
+
+    <ion-spinner *ngIf="loading"></ion-spinner>
   </ion-list>
 
   <ion-infinite-scroll (ionInfinite)="$event.waitFor(loadItems())" [enabled]="loadMoreItems">

--- a/src/pages/inventory/inventory.ts
+++ b/src/pages/inventory/inventory.ts
@@ -26,6 +26,7 @@ export class InventoryPage {
   items;
   offset;
   loadMoreItems = true;
+  loading = false;
 
   constructor(
     public navCtrl: NavController,
@@ -67,6 +68,7 @@ export class InventoryPage {
    * Apply current filters on items by calling loadItems().
    */
   onFilterItems() {
+    this.loading = true;
     if (Math.sign(this.selectedBrandID) < 0) {
       this.selectedModelID = -1;
     }
@@ -74,7 +76,9 @@ export class InventoryPage {
     this.items = [];
     this.offset = 0;
     this.loadMoreItems = true;
-    this.loadItems();
+    this.loadItems().then(
+      () => this.loading = false
+    );
   }
 
  /**

--- a/src/pages/kits/kits.html
+++ b/src/pages/kits/kits.html
@@ -16,9 +16,11 @@
       <h2>{{ kit.name }}</h2>
     </button>
 
-    <ion-item *ngIf="!kits.length">
+    <ion-item *ngIf="!kits.length && !loading">
       No kits found
     </ion-item>
+
+    <ion-spinner *ngIf="loading"></ion-spinner>
   </ion-list>
 
   <ion-infinite-scroll (ionInfinite)="$event.waitFor(loadKits())" [enabled]="loadMoreItems">

--- a/src/pages/kits/kits.ts
+++ b/src/pages/kits/kits.ts
@@ -15,6 +15,7 @@ export class KitsPage {
   kits = [];
   loadMoreItems = true;
   offset;
+  loading = false;
 
   constructor(
     public navCtrl: NavController,
@@ -28,7 +29,10 @@ export class KitsPage {
    * modified by the user.
    */
   ngOnInit() {
-    this.loadKits();
+    this.loading = true;
+    this.loadKits().then(
+      () => this.loading = false
+    );
 
     this.events.subscribe('kit:edited', kit => {
       const index = this.kits.findIndex(element => element.kitID === kit.kitID);

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, Events } from 'ionic-angular';
+import { NavController, Events, LoadingController } from 'ionic-angular';
 
 import { TabsPage } from '../tabs/tabs';
 import { UserData } from '../../providers/user-data';
@@ -16,24 +16,33 @@ export class LoginPage {
     public navCtrl: NavController,
     public userData: UserData,
     public notifications: Notifications,
-    public events: Events
+    public events: Events,
+    public loadingCtrl: LoadingController
   ) { }
 
   /**
    * Calls the api with credentials to login and goes to TabsPage if successful.
    */
   onLogin() {
+    let loading = this.loadingCtrl.create({
+      content: 'Logging you in, please wait...'
+    });
+
+    loading.present();
+
     this.userData.login(this.login.email, this.login.password).then(
       (data: any) => {
         this.userData.setUser().then(
           data => {
             this.events.publish('user:login');
+            loading.dismiss();
             this.navCtrl.setRoot(TabsPage);
           }
         );
       },
       err => {
         this.login.password = '';
+        loading.dismiss();
         this.notifications.showToast(err);
       }
     );

--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController, NavParams, LoadingController } from 'ionic-angular';
 
 import { ItemData } from '../../providers/item-data';
 import { Notifications } from '../../providers/notifications';
@@ -17,7 +17,8 @@ export class RentalDetailsPage {
     public navCtrl: NavController,
     public navParams: NavParams,
     public itemData: ItemData,
-    public notifications: Notifications
+    public notifications: Notifications,
+    public loadingCtrl: LoadingController
   ) { }
 
   /**
@@ -43,6 +44,12 @@ export class RentalDetailsPage {
     this.details.startDate = new Date(this.details.startDate).toISOString().substring(0, 10);
     this.details.endDate = new Date(this.details.endDate).toISOString().substring(0, 10);
 
+    let loading = this.loadingCtrl.create({
+      content: 'Renting your item(s), please wait...'
+    });
+
+    loading.present();
+
     let rentals = [];
 
     for (const item of this.items) {
@@ -58,9 +65,13 @@ export class RentalDetailsPage {
     Promise.all(rentals).then(
       success => {
         this.notifications.showToast(Messages.itemsRented);
+        loading.dismiss();
         this.navCtrl.popToRoot();
       },
-      err => this.notifications.showToast(err)
+      err => {
+        loading.dismiss();
+        this.notifications.showToast(err);
+      }
     );
   }
 }

--- a/src/pages/rental/rental.ts
+++ b/src/pages/rental/rental.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams, Events, Platform, AlertController } from 'ionic-angular';
+import { NavController, NavParams, Events, Platform, AlertController, LoadingController } from 'ionic-angular';
 import { BarcodeScanner } from '@ionic-native/barcode-scanner';
 
 import { ItemData } from '../../providers/item-data';
@@ -25,7 +25,8 @@ export class RentalPage {
     public events: Events,
     public barcodeScanner: BarcodeScanner,
     public platform: Platform,
-    public alertCtrl: AlertController
+    public alertCtrl: AlertController,
+    public loadingCtrl: LoadingController
   ) { }
 
   /**
@@ -96,6 +97,12 @@ export class RentalPage {
    * return. Pops the nav when done.
    */
   onReturn() {
+    let loading = this.loadingCtrl.create({
+      content: 'Returning your item(s), please wait...'
+    });
+
+    loading.present();
+
     let returns = [];
 
     for (const item of this.items) {
@@ -105,9 +112,13 @@ export class RentalPage {
     Promise.all(returns).then(
       success => {
         this.notifications.showToast(Messages.itemsReturned);
+        loading.dismiss();
         this.navCtrl.pop();
       },
-      err => this.notifications.showToast(err)
+      err => {
+        loading.dismiss();
+        this.notifications.showToast(err);
+      }
     );
   }
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -11,9 +11,9 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import { BarcodeScanner } from '@ionic-native/barcode-scanner';
-import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams, ModalController, AlertController, Events } from 'ionic-angular';
+import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams, ModalController, AlertController, Events, LoadingController } from 'ionic-angular';
 import { NgForm } from '@angular/forms';
-import { ConfigMock, PlatformMock, NavMock, NavParamsMock, ItemDataMock, KitDataMock, ItemPropertyDataMock, UserDataMock, ModalMock, NotificationsMock, AlertMock, BarcodeScannerMock } from './mocks';
+import { ConfigMock, PlatformMock, NavMock, NavParamsMock, ItemDataMock, KitDataMock, ItemPropertyDataMock, UserDataMock, ModalMock, NotificationsMock, AlertMock, BarcodeScannerMock, LoadingMock } from './mocks';
 import { ItemData } from './providers/item-data';
 import { KitData } from './providers/kit-data';
 import { ItemPropertyData } from './providers/item-property-data';
@@ -73,7 +73,8 @@ export class TestUtils {
         { provide: ModalController, useClass: ModalMock },
         { provide: Notifications, useClass: NotificationsMock },
         { provide: AlertController, useClass: AlertMock },
-        { provide: BarcodeScanner, useClass: BarcodeScannerMock }
+        { provide: BarcodeScanner, useClass: BarcodeScannerMock },
+        { provide: LoadingController, useClass: LoadingMock }
       ],
       imports: [
         FormsModule,


### PR DESCRIPTION
Closes #244 and closes #254 

Added loading inside an alert when doing an action that prevents the user from changing page (saving an item or kit, login in, renting/returning, etc.) and loading as a spinner within the page when the user can still interact with the app (viewing inventory or kits).